### PR TITLE
Fix signing bug when loading from a ledger wallet.

### DIFF
--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_message_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_message_signer.jsx
@@ -11,7 +11,7 @@ export default class LedgerKeystoreMessageSigner extends Component {
   handleSign({ signMessage }) {
     const { txData, address, hideMsgSigningModal } = this.props;
     const { kdPath } = address;
-    signMessage(kdPath, txData).then((signedTx) => {
+    signMessage(kdPath, txData.message).then((signedTx) => {
       hideMsgSigningModal({ signedTx });
     });
   }


### PR DESCRIPTION
This makes sure we only pass the message to react-ledger-container so the challenge no longer fails during signing.