### PR TITLE
Add cookiebot script reference (Needed for DGDG-355)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,8 @@
   <link rel="icon" href="favicon.ico" />
   <script src="https://use.typekit.net/qwt3qco.js"></script>
   <script>window.spectrumBuildTime = <%= htmlWebpackPlugin.options.buildTime %>;</script>
+  <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="29766f7c-dafa-4cb8-a6c8-bd9a2bea7b72" type="text/javascript" async></script>
+
   <meta charset="utf-8" />
   <title>
     <%= htmlWebpackPlugin.options.title || 'Webpack App'%>
@@ -19,6 +21,8 @@
     <div class="ui active loader" />
     <noscript>Spectrum requires Javascript to be enabled.</noscript>
   </div>
+
+
   <!-- Start of digix Zendesk Widget script -->
   <script>/*<![CDATA[*/window.zE || (function (e, t, s) { var n = window.zE = window.zEmbed = function () { n._.push(arguments) }, a = n.s = e.createElement(t), r = e.getElementsByTagName(t)[0]; n.set = function (e) { n.set._.push(e) }, n._ = [], n.set._ = [], a.async = true, a.setAttribute("charset", "utf-8"), a.src = "https://static.zdassets.com/ekr/asset_composer.js?key=" + s, n.t = +new Date, a.type = "text/javascript", r.parentNode.insertBefore(a, r) })(document, "script", "6e833e2f-2a9e-459b-bc42-d5afe0b20343");/*]]>*/</script>
   <!-- End of digix Zendesk Widget script -->


### PR DESCRIPTION
This change pre-configures `Cookiebot` on the main html of Governance UI. `governance-ui-components` will then use the loaded instance of `Cookiebot` to display the notification.