### PR TITLE
Log transaction events in Google Analytics

### DIFF
--- a/src/helpers/web3/redux_subprovider.js
+++ b/src/helpers/web3/redux_subprovider.js
@@ -18,12 +18,12 @@ export default class ReduxSubProvider extends HookedWalletEthTx {
     this.rpcNetworkId = networkId;
 
     // overriding https://github.com/MetaMask/provider-engine/blob/master/subproviders/hooked-wallet-ethtx.js
-    this.signTransaction = ({ ui, ...data }, cb) => {
+    this.signTransaction = ({ ui, logTxn, ...data }, cb) => {
       const network = getNetworks(this.rpcStore.getState()).find(({ id }) => id === this.rpcNetworkId) || {};
       const txData = sanitizeData(data, network);
       const address = getAddresses(this.rpcStore.getState()).find(a => a.address === txData.from);
       this.rpcStore
-        .dispatch(showTxSigningModal({ address, txData, ui, network }))
+        .dispatch(showTxSigningModal({ address, txData, ui, network, logTxn }))
         .then(({ signedTx }) => {
           cb(null, signedTx);
         })

--- a/src/libs/material-ui/components/transactions/transaction_info.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_info.jsx
@@ -8,21 +8,42 @@ export default class TransactionInfo extends Component {
   static propTypes = {
     ui: PropTypes.object,
     txData: PropTypes.object.isRequired,
+    logToggleDetails: PropTypes.func,
   }
+
   static defaultProps = {
     ui: undefined,
+    logToggleDetails: undefined,
   }
+
   render() {
-    const { ui, txData } = this.props;
-    const defaultRender = <TransactionInfoTable {...{ txData }} open />;
-    if (!ui) { return defaultRender; }
+    const { logToggleDetails, ui, txData } = this.props;
+
+    const defaultRender = (
+      <TransactionInfoTable
+        open
+        logToggleDetails={logToggleDetails}
+        {...{ txData }}
+      />
+    );
+
+    if (!ui) {
+      return defaultRender;
+    }
+
     const uiEntry = getUI(ui.type);
-    if (!uiEntry || !uiEntry.component) { return defaultRender; }
+    if (!uiEntry || !uiEntry.component) {
+      return defaultRender;
+    }
+
     const TransactionUI = uiEntry.component;
     return (
       <div>
         <TransactionUI {...this.props} />
-        <TransactionInfoTable {...{ txData }} />
+        <TransactionInfoTable
+          logToggleDetails={logToggleDetails}
+          {...{ txData }}
+        />
       </div>
     );
   }

--- a/src/libs/material-ui/components/transactions/transaction_info_table.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_info_table.jsx
@@ -41,14 +41,19 @@ class TransactionInfoTable extends Component {
     open: PropTypes.bool,
     txData: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired,
+    logToggleDetails: PropTypes.func,
   };
+
   static defaultProps = {
     open: false,
+    logToggleDetails: undefined,
   };
+
   constructor(props) {
     super(props);
     this.state = { open: false };
   }
+
   renderTable() {
     const { txData } = this.props;
     return (
@@ -85,6 +90,11 @@ class TransactionInfoTable extends Component {
             className={classes.button}
             onClick={(e) => {
               e.preventDefault();
+              const { logToggleDetails } = this.props;
+              if (logToggleDetails) {
+                logToggleDetails(!open);
+              }
+
               this.setState({ open: !open });
             }}
           >

--- a/src/libs/material-ui/components/transactions/transaction_signing_overlay.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_signing_overlay.jsx
@@ -164,6 +164,11 @@ class TransactionSigningOverlay extends Component {
   };
 
   handleSetLoading(loading, signingAction) {
+    const { logTxn } = this.props.data;
+    if (loading && logTxn) {
+      logTxn.sign();
+    }
+
     this.setState({ loading, signingAction });
   }
 
@@ -183,7 +188,13 @@ class TransactionSigningOverlay extends Component {
     this.setState(defaultState);
     this.props.hideTxSigningModal({ error: 'Could not find Address' });
   }
+
   handleCancel() {
+    const { logTxn } = this.props.data;
+    if (logTxn) {
+      logTxn.cancel();
+    }
+
     this.setState(defaultState);
     this.props.hideTxSigningModal({ error: 'Cancelled Signing' });
   }
@@ -199,7 +210,9 @@ class TransactionSigningOverlay extends Component {
       return null;
     }
 
-    const { network, address, txData, ui } = data;
+    const { network, address, txData, ui, logTxn } = data;
+    const logToggleDetails = logTxn && logTxn.toggleDetails ? logTxn.toggleDetails : undefined;
+
     const { keystore } = address;
     const {
       autoBroadcast,
@@ -241,6 +254,7 @@ class TransactionSigningOverlay extends Component {
             </Grid>
             <Grid item xs={12}>
               <TransactionInfo
+                logToggleDetails={logToggleDetails}
                 {...{ address, ui, txData: newTxData, network }}
               />
             </Grid>
@@ -251,6 +265,7 @@ class TransactionSigningOverlay extends Component {
                     {...{ network, address, txData: newTxData }}
                     setLoading={this.handleSetLoading}
                     hideTxSigningModal={this.handleSign}
+                    logTxn={logTxn}
                   />
                   <Button
                     variant="outlined"
@@ -259,6 +274,10 @@ class TransactionSigningOverlay extends Component {
                     disableTouchRipple
                     onClick={e => {
                       e.preventDefault();
+                      if (logTxn) {
+                        logTxn.toggleAdvanced(!openAdvanced);
+                      }
+
                       this.setState({ openAdvanced: !openAdvanced });
                     }}
                   >

--- a/src/libs/material-ui/keystoreTypes/imtoken/imtoken_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/imtoken/imtoken_keystore_transaction_signer.jsx
@@ -15,7 +15,12 @@ export default class ImTokenKestoreTransactionSigner extends Component {
     const throwErr = (error) => {
       this.props.setLoading(false);
       this.setState({ error });
+      const { logTxn } = this.props;
+      if (logTxn) {
+        logTxn.completeTransaction(false, error);
+      }
     };
+
     try {
       const localWeb3 = new Web3(window.web3.currentProvider);
       const { txData } = this.props;
@@ -49,4 +54,9 @@ ImTokenKestoreTransactionSigner.propTypes = {
   setLoading: PropTypes.func.isRequired,
   hideTxSigningModal: PropTypes.func.isRequired,
   txData: PropTypes.object.isRequired,
+  logTxn: PropTypes.object,
+};
+
+ImTokenKestoreTransactionSigner.defaultProps = {
+  logTxn: undefined,
 };

--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_transaction_signer.jsx
@@ -10,6 +10,9 @@ const styles = {
     color: '#4CAF50',
   },
 };
+
+const CANCEL_SIGNING_ERROR = '6985';
+
 class LedgerKeystoreTransactionSigner extends Component {
   constructor(props) {
     super(props);
@@ -24,14 +27,21 @@ class LedgerKeystoreTransactionSigner extends Component {
       .then((signedTx) => {
         hideTxSigningModal({ signedTx });
       })
-      .catch(error => this.setState({ error }));
+      .catch((error) => {
+        this.setState({ error });
+        const { logTxn } = this.props;
+        if (logTxn) {
+          logTxn.completeTransaction(false, `Ledger Error - ${error}`);
+        }
+      });
   }
   renderError() {
     const { error } = this.state;
-    if (error.includes('6985')) {
+    if (error.includes(CANCEL_SIGNING_ERROR)) {
       this.props.hideTxSigningModal({ error: 'Cancelled Signing' });
       return null;
     }
+
     return <Typography color="error">{`Ledger Error - ${error}`}</Typography>;
   }
   render() {
@@ -71,6 +81,11 @@ LedgerKeystoreTransactionSigner.propTypes = {
   address: PropTypes.object.isRequired,
   txData: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
+  logTxn: PropTypes.object,
+};
+
+LedgerKeystoreTransactionSigner.defaultProps = {
+  logTxn: undefined,
 };
 
 export default withStyles(styles)(LedgerKeystoreTransactionSigner);

--- a/src/libs/material-ui/keystoreTypes/trezor/trezor_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/trezor/trezor_keystore_transaction_signer.jsx
@@ -35,6 +35,10 @@ class TrezorKeystoreTransactionSigner extends Component {
       .catch((error) => {
         setTimeout(() => {
           this.setState({ error });
+          const { logTxn } = this.props;
+          if (logTxn) {
+            logTxn.completeTransaction(false, `Trezor Error - ${error}`);
+          }
         }, 100);
       });
   }
@@ -78,6 +82,11 @@ TrezorKeystoreTransactionSigner.propTypes = {
   address: PropTypes.object.isRequired,
   txData: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
+  logTxn: PropTypes.object,
+};
+
+TrezorKeystoreTransactionSigner.defaultProps = {
+  logTxn: undefined,
 };
 
 export default withStyles(styles)(TrezorKeystoreTransactionSigner);

--- a/src/libs/material-ui/keystoreTypes/v3/v3_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/v3/v3_keystore_transaction_signer.jsx
@@ -72,6 +72,11 @@ class V3KestoreTransactionSigner extends Component {
       const throwErr = error => {
         this.props.setLoading(false, this.signingButton);
         this.setState({ error });
+
+        const { logTxn } = this.props;
+        if (logTxn) {
+          logTxn.completeTransaction(false, error.message);
+        }
       };
       try {
         const { address, txData } = this.props;
@@ -151,7 +156,12 @@ V3KestoreTransactionSigner.propTypes = {
   hideTxSigningModal: PropTypes.func.isRequired,
   address: PropTypes.object.isRequired,
   txData: PropTypes.object.isRequired,
-  classes: PropTypes.object.isRequired
+  classes: PropTypes.object.isRequired,
+  logTxn: PropTypes.object,
+};
+
+V3KestoreTransactionSigner.defaultProps = {
+  logTxn: undefined,
 };
 
 export default withStyles(styles)(V3KestoreTransactionSigner);


### PR DESCRIPTION
Ref: [DGDG-299](https://tracker.digixdev.com/agiles/88-14/89-17?issue=DGDG-299)

If a `logTxn` object is passed via props, then the transaction signing modal will use it to log transaction events. These events include:
- Showing/Hiding Transaction Details
- Showing/Hiding Advanced Tab
- Sigining/Cancelling the transaction
- The resulting status of the transaction (including the error message, in case of failure)