### PR TITLE
Exclude actioncable from babel compilation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,7 @@ const baseConfig = {
       },
       {
         test: /\.(js|jsx)$/,
+        exclude: /actioncable/,
         include: [
           // TODO auto detect es6 modules?
           // TODO replace with dapplet system


### PR DESCRIPTION
Ref: [DGDG-300](https://tracker.digixdev.com/issue/DGDG-300)

`governance-ui-components` is dependent on the `actioncable` package for using GraphQL subscriptions. However, `actioncable` is not compiled in ES6 and will break because we're running everything through `babel-loader`. This diff fixes the bug so `actioncable` works.

See: https://github.com/rails/rails/issues/25649