### PR TITLE
add scripts to start local UI for kovan/production

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:cucumber": "./node_modules/.bin/wdio wdio.development.config.js",
     "test:cucumber:ci": "echo 'Skipping Seleneium Tests'; # TODO: ./node_modules/.bin/wdio wdio.ci.config.js",
     "start": "webpack-dev-server --progress --https",
+    "start:kovan": "DEV_ENVIRONMENT=kovan webpack-dev-server --progress --https",
+    "start:production": "DEV_ENVIRONMENT=production webpack-dev-server --progress --https",
     "build:stats": "rm -rf ./dist/production; STATS=true ENVIRONMENT=production webpack --progress --profile; npm run stats;",
     "stats": "webpack-bundle-analyzer ./dist/stats.json ./dist/production;",
     "build:demo": "rm -rf ./dist/demo; ENVIRONMENT=demo webpack --progress",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,11 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const spectrumConfig = require('./spectrum.config.js');
 // if process.env.ENVIRONMENT is set, always use `production` flag, but pass the ENVIRONMENT, too.
 const environment = process.env.ENVIRONMENT; // could be 'production', 'staging' or null.
+const devEnvironment = process.env.DEV_ENVIRONMENT; // could be 'production', 'staging' or null.
+
 const production = !!environment; // if this is truthy (i.e. set, then we're good)
+
+console.log('environment = ', environment || devEnvironment);
 
 const baseConfig = {
   entry: ['./src/index.jsx'],
@@ -110,9 +114,10 @@ const baseConfig = {
       buildTime: JSON.stringify(new Date()),
     }),
     new CopyWebpackPlugin([{ from: './src/assets/icon.png', to: 'favicon.ico' }]),
+
     new webpack.DefinePlugin({
       'process.env': {
-        ENVIRONMENT: JSON.stringify(environment || 'development'), // staging / production / development
+        ENVIRONMENT: JSON.stringify(environment || devEnvironment || 'development'), // staging / production / development
         NODE_ENV: JSON.stringify(production ? 'production' : 'development'), // for react
       },
     }),


### PR DESCRIPTION
With this commit, we can start a local, auto-recompiling UI for kovan and production (meaning, it talks to the staging/production servers and use the kovan/mainnet contracts)

####  Running for `kovan`:
* Make sure the `@digix/dao-contracts` in `governance-ui-components` is pointing to a kovan deploy, and has been npm installed
* run `npm run start:kovan`

#### Running UI for `production`:
* Make sure the `@digix/dao-contracts` in `governance-ui-components` is pointing to a mainnet deploy, and has been npm installed
* run `npm run start:production`
