### PR TITLE
Make sure ledger gets the updated gas price when signing transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@digix/governance-ui-components": "file:../governance-ui-components",
     "@digix/mui": "file:../react-material-ui-suite",
-    "@digix/react-ledger-container": "^0.1.7",
+    "@digix/react-ledger-container": "^0.1.8",
     "@digix/react-trezor-container": "^1.1.7",
     "@digix/redux-crypto-prices": "0.0.1",
     "@digix/sui-react-ezmodal": "0.0.4",

--- a/src/libs/material-ui/components/transactions/transaction_signing_overlay.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_signing_overlay.jsx
@@ -1,8 +1,9 @@
+/* eslint-disable react/jsx-no-duplicate-props */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-// import { Divider, Modal, Button, Dimmer, Loader } from 'semantic-ui-react';
 
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -22,7 +23,6 @@ import { withStyles } from '@material-ui/core/styles';
 
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
-// import Divider from '@material-ui/core/Divider';
 
 import { getSigningModalData } from '~/selectors';
 import { hideTxSigningModal } from '~/actions/session';
@@ -30,7 +30,6 @@ import { hideTxSigningModal } from '~/actions/session';
 import { getKeystoreComponent } from '../../keystoreTypes';
 
 import TransactionInfo from './transaction_info';
-import Advanced from '../common/advanced';
 
 const defaultState = {
   loading: false,
@@ -38,7 +37,8 @@ const defaultState = {
   signedTx: null,
   signingAction: undefined,
   openAdvanced: false,
-  gasPrice: 20
+  gasPrice: 20,
+  showAdvancedTab: true,
 };
 
 const styles = theme => ({
@@ -129,15 +129,18 @@ const styles = theme => ({
     marginTop: '1em'
   }
 });
+
 class TransactionSigningOverlay extends Component {
   static propTypes = {
     data: PropTypes.object,
     hideTxSigningModal: PropTypes.func.isRequired,
     classes: PropTypes.object.isRequired
   };
+
   static defaultProps = {
     data: undefined
   };
+
   constructor(props) {
     super(props);
     this.state = defaultState;
@@ -176,6 +179,7 @@ class TransactionSigningOverlay extends Component {
     this.setState(defaultState);
     this.props.hideTxSigningModal(...args);
   }
+
   handleSign(...args) {
     this.handleSetLoading(false);
     if (args.error || this.state.autoBroadcast) {
@@ -184,6 +188,7 @@ class TransactionSigningOverlay extends Component {
       this.setState({ signedTx: args[0].signedTx });
     }
   }
+
   handleFailure() {
     this.setState(defaultState);
     this.props.hideTxSigningModal({ error: 'Could not find Address' });
@@ -198,14 +203,112 @@ class TransactionSigningOverlay extends Component {
     this.setState(defaultState);
     this.props.hideTxSigningModal({ error: 'Cancelled Signing' });
   }
+
   handleChange = (name, { min, max }) => event => {
     const value = parseFloat(event.target.value) || min;
     this.setState({
       [name]: value > max ? max : value
     });
   };
+
+  hideAdvancedTab = () => {
+    this.setState({ showAdvancedTab: false });
+  }
+
+  toggleAdvancedTab = (e) => {
+    e.preventDefault();
+    const { logTxn } = this.props.data;
+    const { openAdvanced } = this.state;
+
+    if (logTxn) {
+      logTxn.toggleAdvanced(!openAdvanced);
+    }
+
+    this.setState({ openAdvanced: !openAdvanced });
+  }
+
+  renderAdvancedTab() {
+    const { classes } = this.props;
+    const { gasPrice, openAdvanced, showAdvancedTab } = this.state;
+
+    if (!showAdvancedTab) {
+      return null;
+    }
+
+    const MIN_GWEI = 1;
+    const MAX_GWEI = 100;
+    const range = {
+      min: MIN_GWEI,
+      max: MAX_GWEI,
+    };
+
+    const inputProps = {
+      step: 1,
+      ...range,
+      className: classes.textField,
+    };
+
+    const classProps = {
+      classes: {
+        root: classes.textField,
+        input: classes.noBorder,
+        underline: classes.noBorder,
+      },
+    };
+
+    return (
+      <div>
+        <Button
+          className={classes.advancedBtn}
+          disableRipple
+          disableTouchRipple
+          onClick={this.toggleAdvancedTab}
+          variant="outlined"
+        >
+          Advanced
+          <ExpandMoreIcon
+            className={classnames(classes.expand, {
+              [classes.expandOpen]: openAdvanced,
+            })}
+          />
+        </Button>
+
+        <Collapse in={openAdvanced}>
+          <Card className={classes.card}>
+            <Grid container>
+              <Grid item xs={9} className={classes.noPadding}>
+                <Typography className={classes.typography}>GAS PRICE</Typography>
+              </Grid>
+              <Grid item xs={3} className={classes.voteSelection}>
+                <Typography className={classes.selected} variant="caption">
+                  <TextField
+                    inputProps={inputProps}
+                    InputProps={classProps}
+                    onChange={this.handleChange('gasPrice', range)}
+                    value={gasPrice}
+                    type="number"
+                  />
+                  &nbsp;GWEI
+                </Typography>
+              </Grid>
+              <Grid item xs={12}>
+                <div className={classes.slider}>
+                  <Slider onUpdate={this.setGasPrice} range={range} start={[gasPrice]} step={1} />
+                  <Grid container>
+                    <Grid item xs={6} className={classes.minValue}>{MIN_GWEI}</Grid>
+                    <Grid item xs={6} className={classes.maxValue}>{MAX_GWEI}</Grid>
+                  </Grid>
+                </div>
+              </Grid>
+            </Grid>
+          </Card>
+        </Collapse>
+      </div>
+    );
+  }
+
   render() {
-    const { data, classes } = this.props;
+    const { data } = this.props;
     if (!data) {
       return null;
     }
@@ -215,13 +318,12 @@ class TransactionSigningOverlay extends Component {
 
     const { keystore } = address;
     const {
-      autoBroadcast,
       signedTx,
       signingAction,
       loading,
       gasPrice,
-      openAdvanced
     } = this.state;
+
     if (!txData || !keystore) {
       return null;
     }
@@ -229,13 +331,14 @@ class TransactionSigningOverlay extends Component {
     const { gasPrice: txGas, ...rest } = txData;
     const newTxData = {
       gasPrice: `0x${(Number(gasPrice) * 1e9).toString(16)}`,
-      ...rest
+      ...rest,
     };
 
     const SigningComponent = getKeystoreComponent({
       id: keystore.type.id,
       type: 'transactionSigner'
     });
+
     return (
       <Dialog
         open
@@ -265,89 +368,10 @@ class TransactionSigningOverlay extends Component {
                     {...{ network, address, txData: newTxData }}
                     setLoading={this.handleSetLoading}
                     hideTxSigningModal={this.handleSign}
+                    hideAdvancedTab={this.hideAdvancedTab}
                     logTxn={logTxn}
                   />
-                  <Button
-                    variant="outlined"
-                    className={classes.advancedBtn}
-                    disableRipple
-                    disableTouchRipple
-                    onClick={e => {
-                      e.preventDefault();
-                      if (logTxn) {
-                        logTxn.toggleAdvanced(!openAdvanced);
-                      }
-
-                      this.setState({ openAdvanced: !openAdvanced });
-                    }}
-                  >
-                    Advanced
-                    <ExpandMoreIcon
-                      className={classnames(classes.expand, {
-                        [classes.expandOpen]: openAdvanced
-                      })}
-                    />
-                  </Button>
-
-                  <Collapse in={openAdvanced}>
-                    <Card className={classes.card}>
-                      <Grid container>
-                        <Grid item xs={9} className={classes.noPadding}>
-                          <Typography className={classes.typography}>
-                            GAS PRICE
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={3} className={classes.voteSelection}>
-                          <Typography
-                            className={classes.selected}
-                            variant="caption"
-                          >
-                            <TextField
-                              inputProps={{
-                                step: 1,
-                                min: 1,
-                                max: 100,
-                                className: classes.textField
-                              }}
-                              type="number"
-                              value={gasPrice}
-                              /* eslint-disable react/jsx-no-duplicate-props */
-                              InputProps={{
-                                classes: {
-                                  root: classes.textField,
-                                  input: classes.noBorder,
-                                  underline: classes.noBorder
-                                }
-                              }}
-                              onChange={this.handleChange('gasPrice', {
-                                min: 1,
-                                max: 100
-                              })}
-                            />{' '}
-                            GWEI
-                          </Typography>
-                        </Grid>
-                        <Grid item xs={12}>
-                          <div className={classes.slider}>
-                            <Slider
-                              start={[gasPrice]}
-                              onUpdate={this.setGasPrice}
-                              step={1}
-                              range={{ min: 1, max: 100 }}
-                            />
-                            <Grid container>
-                              <Grid item xs={6} className={classes.minValue}>
-                                1
-                              </Grid>
-                              <Grid item xs={6} className={classes.maxValue}>
-                                100
-                              </Grid>
-                            </Grid>
-                          </div>
-                        </Grid>
-                      </Grid>
-                    </Card>
-                  </Collapse>
+                  {this.renderAdvancedTab()}
                 </div>
               ) : (
                 <div>

--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_transaction_signer.jsx
@@ -1,8 +1,10 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import LedgerContianer from '@digix/react-ledger-container';
-import Typography from '@material-ui/core/Typography';
+
 import Fingerprint from '@material-ui/icons/Fingerprint';
+import LedgerContainer from '@digix/react-ledger-container';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = {
@@ -16,10 +18,15 @@ const CANCEL_SIGNING_ERROR = '6985';
 class LedgerKeystoreTransactionSigner extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      error: undefined,
+    };
+
     this.handleSign = this.handleSign.bind(this);
-    this.state = { error: undefined };
     this.renderError = this.renderError.bind(this);
+    this.renderInitSigning = this.renderInitSigning.bind(this);
   }
+
   handleSign({ signTransaction }) {
     const { txData, address, hideTxSigningModal } = this.props;
     const { kdPath } = address;
@@ -35,6 +42,7 @@ class LedgerKeystoreTransactionSigner extends Component {
         }
       });
   }
+
   renderError() {
     const { error } = this.state;
     if (error.includes(CANCEL_SIGNING_ERROR)) {
@@ -44,39 +52,73 @@ class LedgerKeystoreTransactionSigner extends Component {
 
     return <Typography color="error">{`Ledger Error - ${error}`}</Typography>;
   }
+
+  renderReady = ({ config }) => {
+    const { success } = this.props.classes;
+    const { eip155, version } = config;
+    const protectionStatus = eip155 ? 'enabled' : 'disabled';
+
+    return (
+      <Fragment>
+        <Typography align="center">
+          <Fingerprint classes={{ root: success }} />
+        </Typography>
+        <Typography align="center" className={success} variant="title">
+          Ready to Sign Transaction
+        </Typography>
+        <Typography align="center" className={success} variant="body2">
+          {`Firmware ${version} - replay protection ${protectionStatus}!`}
+        </Typography>
+      </Fragment>
+    );
+  }
+
+  renderInitSigning = ({ initiateSigning }) => {
+    const handleInitiateSigning = () => {
+      this.props.hideAdvancedTab();
+      initiateSigning();
+    };
+
+    const buttonStyle = {
+      display: 'block',
+      margin: '0 auto',
+    };
+
+    return (
+      <Fragment>
+        <p>
+          You can modify the transaction details using the <b>Advanced</b> tab below.
+          Once you are satisfied with the details, please click <b>Sign Transaction</b>
+          to confirm the transaction with your ledger device.
+        </p>
+        <Button variant="outlined" onClick={handleInitiateSigning} style={buttonStyle}>
+          Sign Transaction
+        </Button>
+      </Fragment>
+    );
+  };
+
   render() {
     const { kdPath, address } = this.props.address;
-    const { classes } = this.props;
     const { error } = this.state;
+
     if (error) {
       return this.renderError();
     }
 
     return (
-      <LedgerContianer
+      <LedgerContainer
         expect={{ kdPath, address }}
         onReady={this.handleSign}
-        renderError={() => console.log('error')}
-        onError={() => console.log('on error')}
-        renderReady={({ config }) => (
-          <Fragment>
-            <Typography align="center">
-              <Fingerprint classes={{ root: classes.success }} />
-            </Typography>
-            <Typography variant="title" align="center" className={classes.success}>
-              Ready to Sign Transaction
-            </Typography>
-            <Typography variant="body2" align="center" className={classes.success}>{`Firmware ${
-              config.version
-            } - replay protection ${config.eip155 ? 'en' : 'dis'}abled!`}</Typography>
-          </Fragment>
-        )}
+        renderInitSigning={this.renderInitSigning}
+        renderReady={this.renderReady}
       />
     );
   }
 }
 
 LedgerKeystoreTransactionSigner.propTypes = {
+  hideAdvancedTab: PropTypes.func.isRequired,
   hideTxSigningModal: PropTypes.func.isRequired,
   address: PropTypes.object.isRequired,
   txData: PropTypes.object.isRequired,


### PR DESCRIPTION
Ref: [DGDG-470](https://tracker.digixdev.com/issue/DGDG-470)

### Code Review Notes

Depends on PR [#3](https://github.com/DigixGlobal/react-ledger-container/pull/3) of `react-ledger-container` to be merged and published. For testing locally pre-publication, view the setup notes in the mentioned PR.

### Dev Notes

Bumps `react-ledger-container` to `v0.1.8` and fixes issue with ledger wallets not using the updated gas price in transactions.

Previously, the transaction modal will immediately initiate the transaction upon rendering. Changes in props will not propagate to `<LedgerContainer/>` once this happens, since the component already created a promise that waits for the transaction to be signed by the user. This leads to the bug where, if the user edits the gas price before signing, the new gas price isn't used in the transaction because `<LedgerContainer/>` has already been initialized with the default gas price. `v0.1.8` of `react-ledger-container` should fix this issue by requiring the `renderInitSigning` prop that allows us to manually initiate the transaction from the UI side.

The new UI behavior is detailed in the test plan below.

### Test Plan
- Load a ledger wallet and try to lock some DGD.
- Change the gas price via the **Advanced** tab.
- The transaction modal should have an additional button that initiates the transaction signing. Once you click this button, the **Advanced** tab should disappear and your ledger device will ask you to sign the transaction.
- Sign the transaction and take note of the `txHash` from the resulting snackbar message (or from the Transaction History page).
- You can check if the gas price of the transaction was correct by running the following command on `truffle console`: `web3.eth.getTransaction([txHash])` where `[txHash]` is the hash enclosed in single-quotes.