### PR TITLE
Translate transaction modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-dropzone": "^4.1.3",
     "react-helmet": "^5.2.0",
     "react-hot-loader": "^3.0.0-beta.6",
+    "react-markdown": "^4.0.6",
     "react-qr-reader": "^1.1.3",
     "react-redux": "^5.0.5",
     "react-router": "^4.1.1",

--- a/src/helpers/web3/redux_subprovider.js
+++ b/src/helpers/web3/redux_subprovider.js
@@ -18,12 +18,12 @@ export default class ReduxSubProvider extends HookedWalletEthTx {
     this.rpcNetworkId = networkId;
 
     // overriding https://github.com/MetaMask/provider-engine/blob/master/subproviders/hooked-wallet-ethtx.js
-    this.signTransaction = ({ ui, logTxn, ...data }, cb) => {
+    this.signTransaction = ({ ui, logTxn, translations, ...data }, cb) => {
       const network = getNetworks(this.rpcStore.getState()).find(({ id }) => id === this.rpcNetworkId) || {};
       const txData = sanitizeData(data, network);
       const address = getAddresses(this.rpcStore.getState()).find(a => a.address === txData.from);
       this.rpcStore
-        .dispatch(showTxSigningModal({ address, txData, ui, network, logTxn }))
+        .dispatch(showTxSigningModal({ address, txData, ui, network, logTxn, translations }))
         .then(({ signedTx }) => {
           cb(null, signedTx);
         })

--- a/src/libs/material-ui/components/transactions/transaction_info.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_info.jsx
@@ -9,6 +9,7 @@ export default class TransactionInfo extends Component {
     ui: PropTypes.object,
     txData: PropTypes.object.isRequired,
     logToggleDetails: PropTypes.func,
+    translations: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -17,12 +18,13 @@ export default class TransactionInfo extends Component {
   }
 
   render() {
-    const { logToggleDetails, ui, txData } = this.props;
+    const { logToggleDetails, ui, txData, translations } = this.props;
 
     const defaultRender = (
       <TransactionInfoTable
         open
         logToggleDetails={logToggleDetails}
+        translations={translations}
         {...{ txData }}
       />
     );
@@ -42,6 +44,7 @@ export default class TransactionInfo extends Component {
         <TransactionUI {...this.props} />
         <TransactionInfoTable
           logToggleDetails={logToggleDetails}
+          translations={translations}
           {...{ txData }}
         />
       </div>

--- a/src/libs/material-ui/components/transactions/transaction_info_table.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_info_table.jsx
@@ -42,6 +42,7 @@ class TransactionInfoTable extends Component {
     txData: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired,
     logToggleDetails: PropTypes.func,
+    translations: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -81,7 +82,9 @@ class TransactionInfoTable extends Component {
     if (this.props.open) {
       return this.renderTable();
     }
+    const t = this.props.translations.common;
     const { open } = this.state;
+
     return (
       <div>
         <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
@@ -103,7 +106,7 @@ class TransactionInfoTable extends Component {
                 [classes.expandOpen]: open,
               })}
             />
-            Details
+            {t.details}
           </Button>
         </div>
         <Collapse in={open}>{this.renderTable()}</Collapse>

--- a/src/libs/material-ui/components/transactions/transaction_signing_overlay.jsx
+++ b/src/libs/material-ui/components/transactions/transaction_signing_overlay.jsx
@@ -228,6 +228,7 @@ class TransactionSigningOverlay extends Component {
   }
 
   renderAdvancedTab() {
+    const t = this.props.data.translations.common;
     const { classes } = this.props;
     const { gasPrice, openAdvanced, showAdvancedTab } = this.state;
 
@@ -265,7 +266,7 @@ class TransactionSigningOverlay extends Component {
           onClick={this.toggleAdvancedTab}
           variant="outlined"
         >
-          Advanced
+          {t.advanced}
           <ExpandMoreIcon
             className={classnames(classes.expand, {
               [classes.expandOpen]: openAdvanced,
@@ -277,7 +278,7 @@ class TransactionSigningOverlay extends Component {
           <Card className={classes.card}>
             <Grid container>
               <Grid item xs={9} className={classes.noPadding}>
-                <Typography className={classes.typography}>GAS PRICE</Typography>
+                <Typography className={classes.typography}>{t.gasPrice}</Typography>
               </Grid>
               <Grid item xs={3} className={classes.voteSelection}>
                 <Typography className={classes.selected} variant="caption">
@@ -313,9 +314,10 @@ class TransactionSigningOverlay extends Component {
       return null;
     }
 
-    const { network, address, txData, ui, logTxn } = data;
+    const { network, address, txData, ui, logTxn, translations } = data;
     const logToggleDetails = logTxn && logTxn.toggleDetails ? logTxn.toggleDetails : undefined;
 
+    const t = translations.common;
     const { keystore } = address;
     const {
       signedTx,
@@ -336,7 +338,7 @@ class TransactionSigningOverlay extends Component {
 
     const SigningComponent = getKeystoreComponent({
       id: keystore.type.id,
-      type: 'transactionSigner'
+      type: 'transactionSigner',
     });
 
     return (
@@ -349,7 +351,7 @@ class TransactionSigningOverlay extends Component {
         disableEscapeKeyDown
         fullWidth
       >
-        <DialogTitle id="alert-dialog-title">Transaction Status</DialogTitle>
+        <DialogTitle id="alert-dialog-title">{t.title}</DialogTitle>
         <DialogContent>
           <Grid container spacing={16} direction="column">
             <Grid item xs={12}>
@@ -358,6 +360,7 @@ class TransactionSigningOverlay extends Component {
             <Grid item xs={12}>
               <TransactionInfo
                 logToggleDetails={logToggleDetails}
+                translations={translations}
                 {...{ address, ui, txData: newTxData, network }}
               />
             </Grid>
@@ -369,6 +372,7 @@ class TransactionSigningOverlay extends Component {
                     setLoading={this.handleSetLoading}
                     hideTxSigningModal={this.handleSign}
                     hideAdvancedTab={this.hideAdvancedTab}
+                    translations={translations}
                     logTxn={logTxn}
                   />
                   {this.renderAdvancedTab()}

--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_transaction_signer.jsx
@@ -1,10 +1,12 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
 
 import Fingerprint from '@material-ui/icons/Fingerprint';
 import LedgerContainer from '@digix/react-ledger-container';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
+import { injectTranslation } from '../../../../helpers/stringUtils';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = {
@@ -54,6 +56,7 @@ class LedgerKeystoreTransactionSigner extends Component {
   }
 
   renderReady = ({ config }) => {
+    const t = this.props.translations.Ledger;
     const { success } = this.props.classes;
     const { eip155, version } = config;
     const protectionStatus = eip155 ? 'enabled' : 'disabled';
@@ -64,10 +67,10 @@ class LedgerKeystoreTransactionSigner extends Component {
           <Fingerprint classes={{ root: success }} />
         </Typography>
         <Typography align="center" className={success} variant="title">
-          Ready to Sign Transaction
+          {t.ready}
         </Typography>
         <Typography align="center" className={success} variant="body2">
-          {`Firmware ${version} - replay protection ${protectionStatus}!`}
+          {injectTranslation(t.firmware, { version })}
         </Typography>
       </Fragment>
     );
@@ -84,15 +87,12 @@ class LedgerKeystoreTransactionSigner extends Component {
       margin: '0 auto',
     };
 
+    const t = this.props.translations.common;
     return (
       <Fragment>
-        <p>
-          You can modify the transaction details using the <b>Advanced</b> tab below.
-          Once you are satisfied with the details, please click <b>Sign Transaction</b>
-          to confirm the transaction with your ledger device.
-        </p>
+        <Markdown source={t.modifyInstructions} escapeHtml={false} />
         <Button variant="outlined" onClick={handleInitiateSigning} style={buttonStyle}>
-          Sign Transaction
+          {t.sign}
         </Button>
       </Fragment>
     );
@@ -124,6 +124,7 @@ LedgerKeystoreTransactionSigner.propTypes = {
   txData: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
   logTxn: PropTypes.object,
+  translations: PropTypes.object.isRequired,
 };
 
 LedgerKeystoreTransactionSigner.defaultProps = {

--- a/src/libs/material-ui/keystoreTypes/metamask/metamask_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/metamask/metamask_keystore_transaction_signer.jsx
@@ -71,13 +71,15 @@ class MetaMaskTransactionSigner extends Component {
 
   render() {
     const { classes } = this.props;
+    const t = this.props.translations.Metamask;
+
     return (
       <div style={{ marginTop: '1em' }}>
         <Card className={classes.card} elevation={0}>
           <CardHeader
             avatar={<CircularProgress />}
-            title="Waiting MetaMask Transaction Confirmation"
-            subheader="Please confirm your transaction in MetaMask. If you wish to cancel, click the &quot;Reject&quot; button in MetaMask."
+            title={t.title}
+            subheader={t.description}
           />
         </Card>
       </div>
@@ -92,6 +94,7 @@ MetaMaskTransactionSigner.propTypes = {
   txData: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
   logTxn: PropTypes.object,
+  translations: PropTypes.object.isRequired,
 };
 
 MetaMaskTransactionSigner.defaultProps = {

--- a/src/libs/material-ui/keystoreTypes/trezor/trezor_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/trezor/trezor_keystore_transaction_signer.jsx
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
 import _ from 'lodash';
 import TrezorContainer from '@digix/react-trezor-container';
 import Typography from '@material-ui/core/Typography';
@@ -10,14 +11,15 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = {
   success: {
-    color: '#4CAF50'
-  }
+    color: '#4CAF50',
+  },
 };
 
-const CANCEL_SIGNING_ERROR = 'Action cancelled by user';
 class TrezorKeystoreTransactionSigner extends Component {
   constructor(props) {
     super(props);
+    this.CANCEL_SIGNING_ERROR = 'Action cancelled by user';
+
     this.handleSign = this.handleSign.bind(this);
     this.state = { signed: false, error: false, signing: false };
     this.renderError = this.renderError.bind(this);
@@ -32,6 +34,8 @@ class TrezorKeystoreTransactionSigner extends Component {
   handleSign({ signTransaction }) {
     const { txData, address, hideTxSigningModal } = this.props;
     const { kdPath } = address;
+    const t = this.props.translations.Trezor;
+
     signTransaction(kdPath, txData, hideTxSigningModal)
       .then(signedTx => {
         this.setState({ signed: true });
@@ -42,18 +46,22 @@ class TrezorKeystoreTransactionSigner extends Component {
           this.setState({ error });
           const { logTxn } = this.props;
           if (logTxn) {
-            logTxn.completeTransaction(false, `Trezor Error - ${error}`);
+            logTxn.completeTransaction(false, `${t.error} - ${error}`);
           }
         }, 100);
       });
   }
+
   renderError() {
     const { error } = this.state;
-    if (error.includes(CANCEL_SIGNING_ERROR)) {
+    const t = this.props.translations.Trezor;
+
+    if (error.includes(this.CANCEL_SIGNING_ERROR)) {
       this.props.hideTxSigningModal({ error: 'Cancelled Signing' });
       return null;
     }
-    return <Typography color="error">{`Trezor Error - ${error}`}</Typography>;
+
+    return <Typography color="error">{`${t.error} - ${error}`}</Typography>;
   }
 
   renderInitSigning = () => {
@@ -67,20 +75,16 @@ class TrezorKeystoreTransactionSigner extends Component {
       margin: '0 auto'
     };
 
+    const t = this.props.translations.common;
     return (
       <Fragment>
-        <p>
-          You can modify the transaction details using the <b>Advanced</b> tab
-          below. Once you are satisfied with the details, please click{' '}
-          <b>Sign Transaction</b>
-          to confirm the transaction with your Trezor device.
-        </p>
+        <Markdown source={t.modifyInstructions} escapeHtml={false} />
         <Button
           variant="outlined"
           onClick={handleInitiateSigning}
           style={buttonStyle}
         >
-          Sign Transaction
+          {t.sign}
         </Button>
       </Fragment>
     );
@@ -90,9 +94,12 @@ class TrezorKeystoreTransactionSigner extends Component {
     const { kdPath, address } = this.props.address;
     const { classes } = this.props;
     const { error, signed, signing } = this.state;
+    const t = this.props.translations.Trezor;
+
     if (error) {
       return this.renderError();
     }
+
     return (
       <TrezorContainer
         expect={{ kdPath, address }}
@@ -110,14 +117,14 @@ class TrezorKeystoreTransactionSigner extends Component {
               align="center"
               className={classes.success}
             >
-              Ready to Sign Transaction
+              {t.ready}
             </Typography>
             <Typography
               variant="body2"
               align="center"
               className={classes.success}
             >
-              Please follow instructions on your Trezor Wallet
+              {t.instructions}
             </Typography>
           </Fragment>
         )}
@@ -131,11 +138,12 @@ TrezorKeystoreTransactionSigner.propTypes = {
   address: PropTypes.object.isRequired,
   txData: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
-  logTxn: PropTypes.object
+  logTxn: PropTypes.object,
+  translations: PropTypes.object.isRequired,
 };
 
 TrezorKeystoreTransactionSigner.defaultProps = {
-  logTxn: undefined
+  logTxn: undefined,
 };
 
 export default withStyles(styles)(TrezorKeystoreTransactionSigner);

--- a/src/libs/material-ui/keystoreTypes/v3/v3_keystore_transaction_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/v3/v3_keystore_transaction_signer.jsx
@@ -40,9 +40,12 @@ class V3KestoreTransactionSigner extends Component {
     this.handleChange = this.handleChange.bind(this);
     this.triggerSubmit = this.triggerSubmit.bind(this);
 
-    this.signingButton = () => (
-      <Button onClick={this.triggerSubmit}>Sign Transaction</Button>
-    );
+    this.signingButton = () => {
+      const t = this.props.translations.common;
+      return (
+        <Button onClick={this.triggerSubmit}>{t.sign}</Button>
+      );
+    };
   }
 
   onKeyPress(e) {
@@ -96,6 +99,8 @@ class V3KestoreTransactionSigner extends Component {
   render() {
     const { error, password } = this.state;
     const { classes } = this.props;
+    const t = this.props.translations.Json;
+
     return (
       <div className={classes.root}>
         <form
@@ -113,7 +118,7 @@ class V3KestoreTransactionSigner extends Component {
             <Grid item xs={8} md={12}>
               <FormControl className={classes.textField}>
                 <Input
-                  label="Enter Password"
+                  label={t.password}
                   id="name-simple"
                   value={password}
                   type="password"
@@ -121,8 +126,8 @@ class V3KestoreTransactionSigner extends Component {
                   onChange={this.handleChange}
                   autoFocus
                   fullWidth
-                  placeholder="Enter Password"
-                  helperText="Enter your Password to Sign your Transaction"
+                  placeholder={t.password}
+                  helperText={t.instructions}
                 />
               </FormControl>
             </Grid>
@@ -154,6 +159,7 @@ V3KestoreTransactionSigner.propTypes = {
   txData: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
   logTxn: PropTypes.object,
+  translations: PropTypes.object.isRequired,
 };
 
 V3KestoreTransactionSigner.defaultProps = {


### PR DESCRIPTION
Ref: [DGDG-482](https://tracker.digixdev.com/issue/DGDG-482)

### Code Review Notes

Dependent on PR [#243](https://github.com/DigixGlobal/governance-ui-components/pull/243) in `governance-ui-components`

### Test Plan

- Install `react-markdown`.
- To test that it works for each wallet, load each type and try to lock some DGD. The transaction modal should be translated if you set your language to Chinese.
- Do regression testing for all transactions using the json wallet to ensure that nothing is broken. The regression test should include:
    - The whole project flow
    - Locking and Unlocking DGD
    - Claiming DGX
    - Redeem Badge and Approve Redeem Badge
    - Approve interaction