### PR TITLE
Show error message when the ethereum app on the user's ledger device is not updated

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -272,3 +272,5 @@ export const THEME_SELECTOR = [
   { MaterialUI: 'material-ui' },
   { SemanticUi: 'semantic-ui' },
 ];
+
+export const LATEST_ETHEREUM_APP_LEDGER = '1.2.4';

--- a/src/helpers/stringUtils.js
+++ b/src/helpers/stringUtils.js
@@ -1,5 +1,8 @@
+import React from 'react';
 import util from 'ethereumjs-util';
 import web3Utils from 'web3/lib/utils/utils';
+import Markdown from 'react-markdown';
+import { renderToString } from 'react-dom/server';
 
 // explicitly export all the web3-utils
 export const padLeft = web3Utils.padLeft;
@@ -155,7 +158,7 @@ export function parseQuery(qstr) {
   return query;
 }
 
-export function injectTranslation(translation, toInject) {
+export const injectTranslation = (translation, toInject) => {
   if (!translation || !toInject) {
     return null;
   }
@@ -167,5 +170,11 @@ export function injectTranslation(translation, toInject) {
     injected = injected.replace(`{{${key}}}`, toInject[key]);
   });
 
-  return injected;
-}
+  return <Markdown source={injected} escapeHtml={false} />;
+};
+
+export const isVersionOutdated = (currentVersion, latestVersion) => {
+  const semver = currentVersion.split('.');
+  const latestSemver = latestVersion.split('.');
+  return Number(semver[0]) < latestSemver[0] || Number(semver[1]) < latestSemver[1] || Number(semver[2]) < latestSemver[2];
+};

--- a/src/libs/material-ui/components/MessageSigning/message_signing_overlay.jsx
+++ b/src/libs/material-ui/components/MessageSigning/message_signing_overlay.jsx
@@ -18,6 +18,7 @@ import {
 import web3Connect from '~/helpers/web3/connect';
 import { hideMsgSigningModal } from '~/actions/session';
 import { DialogContent } from '@material-ui/core';
+import { injectTranslation } from '@digix/spectrum/src/helpers/stringUtils';
 
 const defaultState = {
   loading: false,

--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_creation_form.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_creation_form.jsx
@@ -14,10 +14,12 @@ import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import LedgerOutdatedVersionError from '~/libs/material-ui/keystoreTypes/ledger/version_outdated';
 import { withStyles } from '@material-ui/core/styles';
+import { isVersionOutdated } from '~/helpers/stringUtils';
+import { LATEST_ETHEREUM_APP_LEDGER } from '~/helpers/constants';
 
 import EnhancedTableToolbar from '~/libs/material-ui/components/common/EnhancedToolbar';
-
 import LedgerAddressList from './ledger_keystore_address_list';
 import LedgerKeystoreAddressItem from './ledger_keystore_address_item';
 
@@ -177,8 +179,25 @@ class LedgerKeystoreCreationForm extends Component {
     return options;
   }
 
-  render() {
+  renderReady(props) {
+    const isAppOutdated = isVersionOutdated(props.config.version, LATEST_ETHEREUM_APP_LEDGER);
+    if (isAppOutdated) {
+      const t = this.props.translations.chooseAddress;
+      return <LedgerOutdatedVersionError translations={t} />;
+    }
+
     const { renderContainer, renderItem } = this;
+    const { hdPath, customPath: custom, useCustom } = this.state;
+    return (
+      <LedgerAddressList
+        kdPath={!useCustom ? hdPath : custom}
+        {...props}
+        {...{ renderContainer, renderItem }}
+      />
+    );
+  }
+
+  render() {
     const { hdPath, customPath: custom, error, loading, useCustom } = this.state;
     const { classes } = this.props;
     const t = this.props.translations.chooseAddress.selectPath;
@@ -221,9 +240,7 @@ class LedgerKeystoreCreationForm extends Component {
           <Typography color="error" component="div">
             <LedgerContainer
               expect={!useCustom ? { kdPath: hdPath } : custom}
-              renderReady={props => (
-                <LedgerAddressList kdPath={!useCustom ? hdPath : custom} {...props} {...{ renderContainer, renderItem }} />
-              )}
+              renderReady={props => this.renderReady(props)}
             />
           </Typography>
         )}

--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_message_signer.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_message_signer.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import LedgerContainer from '@digix/react-ledger-container';
 import { Message } from 'semantic-ui-react';
-import { injectTranslation } from '../.../..//../../../helpers/stringUtils';
+import { injectTranslation } from '~/helpers/stringUtils';
 
 export default class LedgerKeystoreMessageSigner extends Component {
   constructor(props) {

--- a/src/libs/material-ui/keystoreTypes/ledger/version_outdated.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/version_outdated.jsx
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import { injectTranslation } from '~/helpers/stringUtils';
+import { LATEST_ETHEREUM_APP_LEDGER } from '~/helpers/constants';
+
+class LedgerOutdatedVersionError extends Component {
+  constructor(props) {
+    super(props);
+    this.LEDGER_ETHEREUM_APP_LINK = 'https://support.ledger.com/hc/en-us/articles/360002731113-Update-device-firmware';
+  }
+
+  render() {
+    const t = this.props.translations.errors.outdatedVersion;
+    return (
+      <div>
+        <Typography color="error" variant="body2">
+          {t.title}
+        </Typography>
+        <Typography color="error" variant="body1" component="div">
+          {injectTranslation(t.instructions, {
+            version: LATEST_ETHEREUM_APP_LEDGER,
+            link: this.LEDGER_ETHEREUM_APP_LINK,
+          })}
+        </Typography>
+      </div>
+    );
+  }
+}
+
+const { object } = PropTypes;
+LedgerOutdatedVersionError.propTypes = {
+  translations: object.isRequired,
+};
+
+export default LedgerOutdatedVersionError;


### PR DESCRIPTION
Ref: [DGDG-511](https://tracker.digixdev.com/issue/DGDG-511)

### Code Review Notes

This is dependent on PR [#274](https://github.com/DigixGlobal/governance-ui-components/pull/274) and PR [#288](https://github.com/DigixGlobal/governance-ui-components/pull/288) in `governance-ui-components`.

### Dev Notes

The user will not be able to load their wallet if their Ethereum app is not set to at least `v1.2.4`. This is to ensure that they always have the latest version compatible with our ledger library.

### Test Plan
- Run the translation scripts in `governance-ui-components`. `npm run ui:generate-translations`
- Use a ledger device with an outdated ethereum app and try to load it.
- An error message will show up asking the user to update their device.
- Update the device. The user should be able to load their wallet normally.