### PR TITLE
[FEATURE] - Remove name Popup for Metamask

### DIFF
--- a/src/libs/material-ui/components/keystores/keystore_modal.jsx
+++ b/src/libs/material-ui/components/keystores/keystore_modal.jsx
@@ -8,7 +8,7 @@ import {
   getKeystoreTypes,
   getNetworksWithTokens,
   getDefaultNetworks,
-  getKeystores,
+  getKeystores
 } from '~/selectors';
 
 import config from '~/../spectrum.config';
@@ -29,33 +29,33 @@ const styles = theme => ({
   walletIcon: {
     height: '60px',
     width: '100%',
-    color: theme.palette.secondary.main,
+    color: theme.palette.secondary.main
   },
   root: {
     display: 'flex',
     alignItems: 'center',
-    width: '100%',
+    width: '100%'
   },
   wrapper: {
     position: 'relative',
-    margin: '0 auto',
+    margin: '0 auto'
   },
   rightIcon: {
-    marginLeft: theme.spacing.unit,
+    marginLeft: theme.spacing.unit
   },
   label: {
-    color: theme.palette.primary.main,
+    color: theme.palette.primary.main
   },
   noMinHeight: {
-    minHeight: 'none',
-  },
+    minHeight: 'none'
+  }
 });
 
 const icons = {
   metamask: MetamaskIcon,
   trezor: TrezorIcon,
   ledger: LedgerIcon,
-  imtoken: ImtokenIcon,
+  imtoken: ImtokenIcon
 };
 
 class KeystoreModal extends Component {
@@ -83,7 +83,7 @@ class KeystoreModal extends Component {
     showBalances: PropTypes.bool,
     translations: PropTypes.object,
     commonTranslations: PropTypes.object,
-    logLoadWallet: PropTypes.object,
+    logLoadWallet: PropTypes.object
   };
 
   static defaultProps = {
@@ -103,7 +103,7 @@ class KeystoreModal extends Component {
     showBalances: false,
     translations: undefined,
     commonTranslations: undefined,
-    logLoadWallet: {},
+    logLoadWallet: {}
   };
   constructor(props) {
     super(props);
@@ -135,9 +135,13 @@ class KeystoreModal extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { keystores } = nextProps;
+    const { keystores, skipConfirmation, keystoreType } = nextProps;
     const { keystores: oldStores = [] } = this.props;
     const { createdAccount } = this.state;
+
+    if (skipConfirmation && !createdAccount && keystoreType === 'metamask') {
+      this.enableMetamask();
+    }
 
     let newStore;
     if (this.props.keystores !== nextProps.keystores && createdAccount) {
@@ -183,7 +187,7 @@ class KeystoreModal extends Component {
   }
 
   downloadKeystore(keystore) {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       const { data, addresses } = keystore;
       const parsed = JSON.parse(data);
       const { address } = parsed;
@@ -206,7 +210,7 @@ class KeystoreModal extends Component {
 
     // it's async, lets show some loading UI
     return new Promise((resolve, reject) => {
-      const throwErr = (error) => {
+      const throwErr = error => {
         logLoadWallet.loadError(error);
         this.setState({ loading: false, error });
         return reject();
@@ -222,7 +226,7 @@ class KeystoreModal extends Component {
           }
 
           func = this.props.submitFunc(newFormData || { ...this.state.data }, {
-            ...this.state.data,
+            ...this.state.data
           });
         } catch (error) {
           throwErr(error);
@@ -285,8 +289,7 @@ class KeystoreModal extends Component {
     this.handleClose();
   }
 
-  enableMetamask = (e) => {
-    e.preventDefault();
+  enableMetamask = () => {
     const t = this.props.translations.Name.ConnectionError;
 
     if (!window.ethereum) {
@@ -299,7 +302,10 @@ class KeystoreModal extends Component {
     window.ethereum
       .enable()
       .then(() => {
-        this.handleSubmit();
+        this.handleSubmit({
+          ...this.getDefaultData(),
+          name: 'Metamask Keystore'
+        });
       })
       .catch(() => {
         const { logLoadWallet } = this.props;
@@ -308,7 +314,7 @@ class KeystoreModal extends Component {
       });
   };
 
-  enableOtherWallets = (e) => {
+  enableOtherWallets = e => {
     e.preventDefault();
     this.handleSubmit();
   };
@@ -326,7 +332,7 @@ class KeystoreModal extends Component {
       data: { type },
       skipConfirmation,
       keystoreType,
-      logLoadWallet,
+      logLoadWallet
     } = this.props;
 
     if (skipConfirmation) {
@@ -336,16 +342,19 @@ class KeystoreModal extends Component {
     const keystoreTypes = !config.keystoreTypes
       ? rawKeystores
       : rawKeystores.filter(({ id }) => {
-        if (this.props.allowedKeystoreTypes) {
-          return this.props.allowedKeystoreTypes.indexOf(id) > -1;
-        }
-        return config.keystoreTypes.indexOf(id) > -1;
-      });
+          if (this.props.allowedKeystoreTypes) {
+            return this.props.allowedKeystoreTypes.indexOf(id) > -1;
+          }
+          return config.keystoreTypes.indexOf(id) > -1;
+        });
 
     const Icon = icons[type];
     const t = this.props.translations;
     const tCommon = this.props.commonTranslations;
-    const title = this.state.data.type === 'metamask' ? t.Name.title : t.chooseAddress.title;
+    const title =
+      this.state.data.type === 'metamask'
+        ? t.Name.title
+        : t.chooseAddress.title;
 
     return (
       <Dialog
@@ -373,7 +382,9 @@ class KeystoreModal extends Component {
 
           return (
             <div>
-              <Button onClick={() => this.handleCancel(hide)}>{tCommon.cancel}</Button>
+              <Button onClick={() => this.handleCancel(hide)}>
+                {tCommon.cancel}
+              </Button>
               {showLoadButton && (
                 <Button
                   color="primary"
@@ -409,7 +420,7 @@ class KeystoreModal extends Component {
                 hideSelector,
                 trezor,
                 onSuccess,
-                showBalances,
+                showBalances
               }}
             />
             {this.state.error && (
@@ -428,7 +439,7 @@ const mapStateToProps = state => ({
   keystoreTypes: getKeystoreTypes(state),
   networks: getNetworksWithTokens(state),
   defaultNetworks: getDefaultNetworks(state),
-  keystores: getKeystores(state),
+  keystores: getKeystores(state)
 });
 
 export default connect(mapStateToProps)(withStyles(styles)(KeystoreModal));

--- a/src/libs/material-ui/keystoreTypes/metamask/metamask_keystore_actions.js
+++ b/src/libs/material-ui/keystoreTypes/metamask/metamask_keystore_actions.js
@@ -16,11 +16,17 @@ export function create(formData) {
 
     const { networks, tokens } = formData;
 
+    console.log({ account: window.web3.eth.accounts });
     if (!window.web3) {
-      throw new Error('Cannot connect to MetaMask. Make sure to setup your MetaMask and login to your wallet.');
+      throw new Error(
+        'Cannot connect to MetaMask. Make sure to setup your MetaMask and login to your wallet.'
+      );
     } else if (!window.web3.eth.accounts[0]) {
-      throw new Error('Cannot connect to MetaMask wallet. Make sure to login to your MetaMask wallet.');
+      throw new Error(
+        'Cannot connect to MetaMask wallet. Make sure to login to your MetaMask wallet.'
+      );
     }
+
     const address = window.web3.eth.accounts[0];
     // // ensure it doesnt already exist
     throwIfExistingAddress([address], getState);
@@ -32,18 +38,28 @@ export function create(formData) {
     // create address instance
     dispatch({
       type: addressActions.CREATE_ADDRESS,
-      payload: { address, networks, name, tokens, keystore: id, updateDefaultAddress },
+      payload: {
+        address,
+        networks,
+        name,
+        tokens,
+        keystore: id,
+        updateDefaultAddress
+      }
     });
   };
 }
 
 export function update({ networks, tokens, name }, data) {
-  return (dispatch) => {
+  return dispatch => {
     if (!name) {
       throw new Error('You must provide a name');
     }
 
     const address = data.addresses[0].address;
-    dispatch({ type: addressActions.UPDATE_ADDRESS, payload: { address, networks, tokens, name } });
+    dispatch({
+      type: addressActions.UPDATE_ADDRESS,
+      payload: { address, networks, tokens, name }
+    });
   };
 }

--- a/src/libs/material-ui/keystoreTypes/metamask/metamask_keystore_creation_form.jsx
+++ b/src/libs/material-ui/keystoreTypes/metamask/metamask_keystore_creation_form.jsx
@@ -1,28 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
-import TextField from '@material-ui/core/TextField';
-
 export default class MetamaskKeystoreCreationForm extends Component {
   static propTypes = {
     formChange: PropTypes.func.isRequired,
-    translations: PropTypes.object.isRequired,
+    translations: PropTypes.object.isRequired
   };
 
   render() {
-    const { formChange } = this.props;
-    const t = this.props.translations.Name;
-    return (
-      <div>
-        <TextField
-          label={t.name}
-          placeholder={t.addressNickname}
-          onChange={({ target: { value } }) => {
-            formChange({ name: 'name', value });
-          }}
-          fullWidth
-        />
-      </div>
-    );
+    return null;
   }
 }


### PR DESCRIPTION
Ref [DGDG-560](https://tracker.digixdev.com/issue/DGDG-560)

This feature removes the Popup that requires users to name their Metamask wallet which is not necessary since they are only able to load one wallet at a time. Since naming a wallet is required, this feature will use a hard coded name `Metamask Keystore`.