### PR TITLE
[FIX] Fix loading of ledger wallets with updated ledger library

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@digix/governance-ui-components": "file:../governance-ui-components",
     "@digix/mui": "file:../react-material-ui-suite",
-    "@digix/react-ledger-container": "0.1.8",
+    "@digix/react-ledger-container": "^0.1.10",
     "@digix/react-trezor-container": "^1.1.9",
     "@digix/redux-crypto-prices": "0.0.1",
     "@digix/sui-react-ezmodal": "0.0.4",

--- a/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_address_list.jsx
+++ b/src/libs/material-ui/keystoreTypes/ledger/ledger_keystore_address_list.jsx
@@ -71,7 +71,7 @@ class LedgerAddressList extends Component {
                     resolve(address);
                   })
                   /* eslint-disable no-console */
-                  .fail(console.error)
+                  .catch(console.error)
               );
               /* eslint-enable no-console */
             }),


### PR DESCRIPTION
The `react-ledger-container` was updated to `v0.1.9` which updates its dependencies to fix security issues. The change requires `then...fail` code blocks to be updated to `then...catch` so they're compiled properly.

This bumps the package version to `v0.1.10`.

### Dependencies

This depends on PR [#4](https://github.com/DigixGlobal/react-ledger-container/pull/4) in `react-ledger-container` to be merged and published in npm.

### Test Plan
- Loading a ledger wallet on the marketplace should work.