### PR TITLE
[HOTFIX] Fix build error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,7 +147,7 @@ const baseConfig = {
     })
   ],
   resolve: {
-    extensions: ['.js', '.jsx'],
+    extensions: ['.js', '.jsx', '.json'],
     modules: [
       path.join(__dirname, 'node_modules'),
       'node_modules' // remove when we're not using linked modules


### PR DESCRIPTION
This PR fixes the following error that occurs when building:

```
ERROR in ./node_modules/cids/src/index.js
Module not found: Error: Can't resolve 'multicodec/src/base-table' in '/home/meyagen/Projects/governance/governance-ui/node_modules/cids/src'
 @ ./node_modules/cids/src/index.js 6:15-51
 @ ./node_modules/ipfs-api/src/utils/clean-cid.js
 @ ./node_modules/ipfs-api/src/files/cat.js
 @ ./node_modules/ipfs-api/src/utils/load-commands.js
 @ ./node_modules/ipfs-api/src/index.js
 @ .-components/node_modules/dijix/dist/ipfs.js
 @ .-components/node_modules/dijix/dist/index.js
 @ .-components/src/utils/dijix.js
 @ .-components/src/pages/proposals/details.js
 @ .-components/src/pages/proposals/index.js
 @ .-components/src/index.js
 @ ./src/libs/material-ui/components/app.jsx
 @ ./src/index.jsx
 @ multi (webpack)-dev-server/client?https://localhost:3000 webpack/hot/only-dev-server react-hot-loader/patch ./src/index.jsx
```

The issue seems to be that `base-table.json` is being imported as a module, which webpack does not recognize since it's a json file and webpack is configured to only resolve `.js` and `.jsx` files.